### PR TITLE
Allow passing a list of torrent ids as argument

### DIFF
--- a/manual-tracker-add.sh
+++ b/manual-tracker-add.sh
@@ -27,7 +27,7 @@ done
 }
 
 # Get list of active torrents
-ids="$(transmission-remote "$host" --auth="$auth" --list | grep -vE 'Seeding|Stopped|Finished' | grep '^ ' | awk '{ print $1 }')"
+ids=${1:-"$(transmission-remote "$host" --auth="$auth" --list | grep -vE 'Seeding|Stopped|Finished' | grep '^ ' | awk '{ print $1 }')"}
 
 for id in $ids ; do
     hash="$(transmission-remote "$host" --auth="$auth"  --torrent "$id" --info | grep '^  Hash: ' | awk '{ print $2 }')"


### PR DESCRIPTION
Allow passing a quoted enclosed, space separated list of torrent ids as argument. If none passed, run on all torrents as usual.
Useful if you want to add trackers only to specific torrents.

