### PR TITLE
Update tracker scripts `grep' behaviour

### DIFF
--- a/manual-tracker-add.sh
+++ b/manual-tracker-add.sh
@@ -20,10 +20,10 @@ for tracker in $(curl --location -# "${base_url}") ; do
     echo -en "\e[0m"
     echo -ne "\e[93m*\e[0m ${tracker}..."
 if transmission-remote "$host" ${auth:+--auth="$auth"} --torrent "${torrent_hash}" -td "${tracker}" | grep -q 'success'; then
-    echo -e '\e[91m failed.'
+    echo -e '\e[92m done.'
     echo -en "\e[0m"
 else
-    echo -e '\e[92m done.'
+    echo -e '\e[93m already added.'
     echo -en "\e[0m"
 fi
  done

--- a/tracker-add-auto.sh
+++ b/tracker-add-auto.sh
@@ -23,9 +23,9 @@ fi
 for tracker in $(cat $trackerslist) ; do
     echo -n "${tracker}..."
 if transmission-remote "$host"  --auth="$auth" --torrent "${torrent_hash}" -td "${tracker}" | grep -q 'success'; then
-    echo ' failed.'
-else
     echo ' done.'
+else
+    echo ' already added.'
 fi
 done
 done


### PR DESCRIPTION
According to manual page and [StackOverflow](https://stackoverflow.com/a/56170435/8597016), when there is a match grep returns '`SUCCESS`', so the logic of the `if` code must be inverted. In addition, for better output readability, instead of **failure** the output may be *already added* as `transmission-remote` says "Invalid argument" when a torrent has the specific tracker included